### PR TITLE
Configure ruff to report but not auto-fix unused imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ select = [
 ignore = [
     "E501",  # Line too long (handled by formatter)
 ]
+unfixable = [
+    "F401",  # Unused imports - report but don't auto-remove
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["main"]


### PR DESCRIPTION
Added unfixable configuration for F401 (unused imports) to prevent automatic removal of imports during linting. This allows imports to be added in one change and used in subsequent changes without being prematurely removed by the auto-formatter.

Auto-formatting for spacing, line length, and import sorting still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)