### PR TITLE
Add LSP bridge daemon for real-time TypeScript and Python diagnostics

### DIFF
--- a/.claude/hooks/lsp-bridge-stop.sh
+++ b/.claude/hooks/lsp-bridge-stop.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# SessionEnd Hook: Stop the LSP bridge daemon
+#
+# Sends a shutdown request to the bridge and cleans up PID/socket files.
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+PID_FILE="$PROJECT_DIR/.claude/hooks/lsp-bridge.pid"
+SOCKET_FILE="$PROJECT_DIR/.claude/hooks/lsp-bridge.socket"
+
+# Try graceful shutdown via API first
+if [ -f "$SOCKET_FILE" ]; then
+  SOCKET_PATH=$(cat "$SOCKET_FILE")
+  if [ -S "$SOCKET_PATH" ]; then
+    curl -s --unix-socket "$SOCKET_PATH" \
+      -X POST "http://localhost/shutdown" > /dev/null 2>&1 || true
+    # Give it a moment to clean up
+    sleep 1
+  fi
+fi
+
+# If still running, kill by PID
+if [ -f "$PID_FILE" ]; then
+  PID=$(cat "$PID_FILE")
+  if kill -0 "$PID" 2>/dev/null; then
+    kill "$PID" 2>/dev/null || true
+    # Wait briefly, then force kill if needed
+    sleep 1
+    if kill -0 "$PID" 2>/dev/null; then
+      kill -9 "$PID" 2>/dev/null || true
+    fi
+  fi
+  rm -f "$PID_FILE"
+fi
+
+# Clean up socket files
+if [ -f "$SOCKET_FILE" ]; then
+  SOCKET_PATH=$(cat "$SOCKET_FILE")
+  rm -f "$SOCKET_PATH" 2>/dev/null || true
+  rm -f "$SOCKET_FILE"
+fi
+
+echo '{}'

--- a/.claude/hooks/lsp-bridge.mjs
+++ b/.claude/hooks/lsp-bridge.mjs
@@ -1,0 +1,681 @@
+#!/usr/bin/env node
+
+/**
+ * LSP Bridge Daemon for Claude Code Hooks
+ *
+ * Spawns multiple language servers (TypeScript, Ruff for Python), communicates
+ * via LSP JSON-RPC, and exposes an HTTP API over a Unix socket so that
+ * PostToolUse hooks can request diagnostics for individual files.
+ *
+ * Usage:
+ *   node lsp-bridge.mjs
+ *
+ * API:
+ *   POST /diagnostics  { "file": "/absolute/path.ts" }  → diagnostics JSON
+ *   GET  /health                                         → { "status": "ok", servers: [...] }
+ *   POST /shutdown                                       → graceful shutdown
+ */
+
+import { spawn, execSync } from "child_process";
+import { createServer } from "http";
+import {
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  existsSync,
+  mkdirSync,
+  appendFileSync,
+} from "fs";
+import { join, resolve, extname } from "path";
+import { createHash } from "crypto";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const PROJECT_DIR =
+  process.env.CLAUDE_PROJECT_DIR || process.argv[2] || process.cwd();
+const FRONTEND_DIR = join(PROJECT_DIR, "frontend");
+
+// Derive a stable socket path from the project dir (keeps path short for Unix socket limit)
+const dirHash = createHash("md5")
+  .update(PROJECT_DIR)
+  .digest("hex")
+  .slice(0, 12);
+const SOCKET_PATH =
+  process.env.LSP_BRIDGE_SOCKET || `/tmp/claude-lsp-${dirHash}.sock`;
+const STATE_DIR = join(PROJECT_DIR, ".claude", "hooks");
+const PID_FILE = join(STATE_DIR, "lsp-bridge.pid");
+const SOCKET_FILE = join(STATE_DIR, "lsp-bridge.socket");
+const LOG_FILE = join(STATE_DIR, "lsp-bridge.log");
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+function log(level, msg) {
+  const ts = new Date().toISOString();
+  const line = `[${ts}] [${level}] ${msg}\n`;
+  try {
+    appendFileSync(LOG_FILE, line);
+  } catch {
+    // ignore write errors
+  }
+  if (level === "ERROR") {
+    process.stderr.write(line);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LSP JSON-RPC Client — generic, works with any LSP server
+// ---------------------------------------------------------------------------
+
+class LSPClient {
+  /**
+   * @param {string} name - Human-readable name for logging (e.g. "typescript", "ruff")
+   * @param {object} spawnOpts - { command, args, cwd, env }
+   * @param {object} initOpts - { rootUri, rootPath, workspaceFolders }
+   */
+  constructor(name, spawnOpts, initOpts) {
+    this.name = name;
+    this._spawnOpts = spawnOpts;
+    this._initOpts = initOpts;
+    this._nextId = 1;
+    this._pending = new Map(); // id → { resolve, reject, timer }
+    this._diagnostics = new Map(); // uri → { diagnostics, waiters[] }
+    this._buffer = Buffer.alloc(0);
+    this._contentLength = -1;
+    this._initialized = false;
+    this._openDocuments = new Map(); // uri → version
+    this._serverProcess = null;
+    this._alive = false;
+  }
+
+  /**
+   * Spawn the language server and wire up communication.
+   */
+  start() {
+    const { command, args, cwd, env } = this._spawnOpts;
+
+    this._serverProcess = spawn(command, args, {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    this._serverProcess.stdout.on("data", (chunk) => this._onData(chunk));
+    this._serverProcess.stderr.on("data", (chunk) => {
+      log(`${this.name}-STDERR`, chunk.toString().trim());
+    });
+    this._serverProcess.on("exit", (code) => {
+      log("INFO", `[${this.name}] LSP server exited with code ${code}`);
+      this._alive = false;
+      // Reject all pending requests
+      for (const [, entry] of this._pending) {
+        entry.reject(new Error(`[${this.name}] LSP server exited (code ${code})`));
+        if (entry.timer) clearTimeout(entry.timer);
+      }
+      this._pending.clear();
+    });
+
+    this._alive = true;
+    log("INFO", `[${this.name}] LSP server spawned (PID ${this._serverProcess.pid})`);
+  }
+
+  /**
+   * Send the initialize handshake.
+   */
+  async initialize() {
+    const { rootUri, rootPath, workspaceFolders } = this._initOpts;
+
+    const result = await this.request("initialize", {
+      processId: process.pid,
+      rootUri,
+      rootPath,
+      capabilities: {
+        textDocument: {
+          publishDiagnostics: {
+            relatedInformation: true,
+          },
+          synchronization: {
+            didOpen: true,
+            didChange: true,
+            didClose: true,
+          },
+        },
+        workspace: {
+          workspaceFolders: true,
+        },
+      },
+      workspaceFolders,
+    });
+
+    this.notify("initialized", {});
+    this._initialized = true;
+    log("INFO", `[${this.name}] LSP initialized successfully`);
+    return result;
+  }
+
+  get isAlive() {
+    return this._alive && this._initialized;
+  }
+
+  /**
+   * Get diagnostics for a file. Closes the document if already open, then
+   * reopens it to reliably trigger publishDiagnostics from all LSP servers.
+   */
+  async getDiagnostics(filePath, languageId, timeoutMs = 15000) {
+    const absPath = resolve(filePath);
+    const uri = `file://${absPath}`;
+    const text = readFileSync(absPath, "utf-8");
+
+    // Close if already open — some LSP servers (e.g. typescript-language-server)
+    // don't reliably re-publish diagnostics on didChange
+    if (this._openDocuments.has(uri)) {
+      this.notify("textDocument/didClose", {
+        textDocument: { uri },
+      });
+      this._openDocuments.delete(uri);
+
+      // Wait for the empty diagnostics that the server publishes on close.
+      // We set up a waiter and let it resolve (empty or not), then discard it.
+      await this._waitForDiagnostics(uri, 2000);
+      this._diagnostics.delete(uri);
+    }
+
+    // Prepare a waiter for diagnostics on this URI
+    const diagnosticPromise = this._waitForDiagnostics(uri, timeoutMs);
+
+    // Open the document fresh
+    const version = 1;
+    this._openDocuments.set(uri, version);
+    this.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId, version, text },
+    });
+
+    return diagnosticPromise;
+  }
+
+  /**
+   * Close a document so the LSP can free resources.
+   */
+  closeDocument(filePath) {
+    const uri = `file://${resolve(filePath)}`;
+    if (this._openDocuments.has(uri)) {
+      this.notify("textDocument/didClose", {
+        textDocument: { uri },
+      });
+      this._openDocuments.delete(uri);
+    }
+  }
+
+  /**
+   * Graceful shutdown per LSP spec.
+   */
+  async shutdown() {
+    if (!this._alive) return;
+    try {
+      await this.request("shutdown", null, 5000);
+      this.notify("exit", null);
+    } catch {
+      // Force kill if shutdown fails
+      if (this._serverProcess) {
+        this._serverProcess.kill("SIGKILL");
+      }
+    }
+  }
+
+  // ---- JSON-RPC transport -------------------------------------------------
+
+  request(method, params, timeoutMs = 30000) {
+    return new Promise((resolve, reject) => {
+      const id = this._nextId++;
+      const timer = setTimeout(() => {
+        this._pending.delete(id);
+        reject(new Error(`[${this.name}] LSP request '${method}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this._pending.set(id, { resolve, reject, timer });
+      this._send({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  notify(method, params) {
+    this._send({ jsonrpc: "2.0", method, params });
+  }
+
+  _send(msg) {
+    const body = JSON.stringify(msg);
+    const header = `Content-Length: ${Buffer.byteLength(body)}\r\n\r\n`;
+    try {
+      this._serverProcess.stdin.write(header + body);
+    } catch (err) {
+      log("ERROR", `[${this.name}] Failed to write to LSP stdin: ${err.message}`);
+    }
+  }
+
+  _onData(chunk) {
+    this._buffer = Buffer.concat([this._buffer, chunk]);
+    this._parseMessages();
+  }
+
+  _parseMessages() {
+    while (true) {
+      if (this._contentLength === -1) {
+        // Look for the header boundary
+        const headerEnd = this._buffer.indexOf("\r\n\r\n");
+        if (headerEnd === -1) return;
+
+        const header = this._buffer.slice(0, headerEnd).toString("ascii");
+        const match = header.match(/Content-Length:\s*(\d+)/i);
+        if (!match) {
+          log("ERROR", `[${this.name}] Invalid LSP header: ${header}`);
+          this._buffer = this._buffer.slice(headerEnd + 4);
+          continue;
+        }
+        this._contentLength = parseInt(match[1], 10);
+        this._buffer = this._buffer.slice(headerEnd + 4);
+      }
+
+      if (this._buffer.length < this._contentLength) return;
+
+      const body = this._buffer.slice(0, this._contentLength).toString("utf-8");
+      this._buffer = this._buffer.slice(this._contentLength);
+      this._contentLength = -1;
+
+      try {
+        const msg = JSON.parse(body);
+        this._handleMessage(msg);
+      } catch (err) {
+        log("ERROR", `[${this.name}] Failed to parse LSP message: ${err.message}`);
+      }
+    }
+  }
+
+  _handleMessage(msg) {
+    // Response to a request
+    if (msg.id !== undefined && (msg.result !== undefined || msg.error)) {
+      const entry = this._pending.get(msg.id);
+      if (entry) {
+        this._pending.delete(msg.id);
+        if (entry.timer) clearTimeout(entry.timer);
+        if (msg.error) {
+          entry.reject(
+            new Error(`[${this.name}] LSP error ${msg.error.code}: ${msg.error.message}`),
+          );
+        } else {
+          entry.resolve(msg.result);
+        }
+      }
+      return;
+    }
+
+    // Notification from server
+    if (msg.method === "textDocument/publishDiagnostics") {
+      const { uri, diagnostics } = msg.params;
+      const entry = this._diagnostics.get(uri);
+      if (entry) {
+        entry.diagnostics = diagnostics;
+        // Resolve all waiters
+        for (const waiter of entry.waiters) {
+          waiter.resolve(diagnostics);
+          if (waiter.timer) clearTimeout(waiter.timer);
+        }
+        entry.waiters = [];
+      } else {
+        // Cache even if nobody's waiting
+        this._diagnostics.set(uri, { diagnostics, waiters: [] });
+      }
+      return;
+    }
+
+    // Log other notifications for debugging
+    if (msg.method) {
+      log("DEBUG", `[${this.name}] LSP notification: ${msg.method}`);
+    }
+  }
+
+  _waitForDiagnostics(uri, timeoutMs) {
+    return new Promise((resolve) => {
+      if (!this._diagnostics.has(uri)) {
+        this._diagnostics.set(uri, { diagnostics: null, waiters: [] });
+      }
+
+      const entry = this._diagnostics.get(uri);
+
+      const timer = setTimeout(() => {
+        // Remove this waiter
+        entry.waiters = entry.waiters.filter((w) => w !== waiter);
+        // Return whatever we have (might be stale or null)
+        resolve(entry.diagnostics || []);
+      }, timeoutMs);
+
+      const waiter = { resolve, timer };
+      entry.waiters.push(waiter);
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Language routing — maps file extensions to LSP clients
+// ---------------------------------------------------------------------------
+
+const EXT_TO_LANGUAGE = {
+  ".ts": { id: "typescript", server: "typescript" },
+  ".tsx": { id: "typescriptreact", server: "typescript" },
+  ".js": { id: "javascript", server: "typescript" },
+  ".jsx": { id: "javascriptreact", server: "typescript" },
+  ".py": { id: "python", server: "ruff" },
+  ".pyi": { id: "python", server: "ruff" },
+};
+
+function getLanguageInfo(filePath) {
+  const ext = extname(filePath).toLowerCase();
+  return EXT_TO_LANGUAGE[ext] || null;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP API Server
+// ---------------------------------------------------------------------------
+
+function createApiServer(servers) {
+  return createServer(async (req, res) => {
+    // Collect request body
+    const body = await new Promise((resolve) => {
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    });
+
+    res.setHeader("Content-Type", "application/json");
+
+    try {
+      // --- Health check ---
+      if (req.url === "/health") {
+        const serverStatus = {};
+        for (const [name, client] of Object.entries(servers)) {
+          serverStatus[name] = client.isAlive ? "ok" : "down";
+        }
+        res.end(JSON.stringify({ status: "ok", pid: process.pid, servers: serverStatus }));
+        return;
+      }
+
+      // --- Diagnostics ---
+      if (req.method === "POST" && req.url === "/diagnostics") {
+        const { file } = JSON.parse(body);
+        if (!file) {
+          res.statusCode = 400;
+          res.end(JSON.stringify({ error: "Missing 'file' in request body" }));
+          return;
+        }
+
+        if (!existsSync(file)) {
+          res.statusCode = 404;
+          res.end(JSON.stringify({ error: `File not found: ${file}` }));
+          return;
+        }
+
+        const langInfo = getLanguageInfo(file);
+        if (!langInfo) {
+          res.end(JSON.stringify({ file, diagnostics: [], note: "unsupported file type" }));
+          return;
+        }
+
+        const client = servers[langInfo.server];
+        if (!client || !client.isAlive) {
+          res.end(JSON.stringify({
+            file,
+            diagnostics: [],
+            note: `${langInfo.server} LSP not available`,
+          }));
+          return;
+        }
+
+        log("INFO", `Checking diagnostics for: ${file} (server: ${langInfo.server})`);
+        const diagnostics = await client.getDiagnostics(file, langInfo.id);
+
+        // Format diagnostics into a useful response
+        const formatted = (diagnostics || []).map((d) => ({
+          severity: severityName(d.severity),
+          message: d.message,
+          range: {
+            start: { line: d.range.start.line + 1, character: d.range.start.character },
+            end: { line: d.range.end.line + 1, character: d.range.end.character },
+          },
+          source: d.source || langInfo.server,
+          code: d.code,
+        }));
+
+        res.end(JSON.stringify({ file, diagnostics: formatted }));
+        return;
+      }
+
+      // --- Shutdown ---
+      if (req.method === "POST" && req.url === "/shutdown") {
+        res.end(JSON.stringify({ status: "shutting_down" }));
+        log("INFO", "Shutdown requested via API");
+        await cleanup();
+        return;
+      }
+
+      // --- 404 ---
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: "Not found" }));
+    } catch (err) {
+      log("ERROR", `API error: ${err.message}`);
+      res.statusCode = 500;
+      res.end(JSON.stringify({ error: err.message }));
+    }
+  });
+}
+
+function severityName(severity) {
+  switch (severity) {
+    case 1:
+      return "error";
+    case 2:
+      return "warning";
+    case 3:
+      return "information";
+    case 4:
+      return "hint";
+    default:
+      return "unknown";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server factory — creates LSP clients for available servers
+// ---------------------------------------------------------------------------
+
+async function createServers() {
+  const servers = {};
+
+  // --- TypeScript Language Server ---
+  const tsLspBin = join(FRONTEND_DIR, "node_modules", ".bin", "typescript-language-server");
+  if (existsSync(tsLspBin) && existsSync(join(FRONTEND_DIR, "tsconfig.json"))) {
+    const rootUri = `file://${FRONTEND_DIR}`;
+    const client = new LSPClient(
+      "typescript",
+      {
+        command: tsLspBin,
+        args: ["--stdio"],
+        cwd: FRONTEND_DIR,
+        env: {
+          PATH: `${join(FRONTEND_DIR, "node_modules", ".bin")}:${process.env.PATH}`,
+        },
+      },
+      {
+        rootUri,
+        rootPath: FRONTEND_DIR,
+        workspaceFolders: [{ uri: rootUri, name: "frontend" }],
+      },
+    );
+
+    try {
+      client.start();
+      await client.initialize();
+      servers.typescript = client;
+      log("INFO", "TypeScript LSP server ready");
+    } catch (err) {
+      log("ERROR", `Failed to start TypeScript LSP: ${err.message}`);
+    }
+  } else {
+    log("INFO", "TypeScript LSP skipped (typescript-language-server or tsconfig.json not found)");
+  }
+
+  // --- Ruff Language Server (Python) ---
+  // Ruff has a built-in LSP: `ruff server`
+  let ruffBin = null;
+
+  // Check for ruff in venv first, then uv-managed, then PATH
+  const ruffLocations = [
+    join(PROJECT_DIR, ".venv", "bin", "ruff"),
+    join(PROJECT_DIR, "node_modules", ".bin", "ruff"),
+  ];
+  for (const loc of ruffLocations) {
+    if (existsSync(loc)) {
+      ruffBin = loc;
+      break;
+    }
+  }
+  if (!ruffBin) {
+    // Try PATH
+    try {
+      ruffBin = execSync("which ruff", { encoding: "utf-8" }).trim();
+    } catch {
+      // not found
+    }
+  }
+
+  if (ruffBin) {
+    const rootUri = `file://${PROJECT_DIR}`;
+    const client = new LSPClient(
+      "ruff",
+      {
+        command: ruffBin,
+        args: ["server"],
+        cwd: PROJECT_DIR,
+        env: {},
+      },
+      {
+        rootUri,
+        rootPath: PROJECT_DIR,
+        workspaceFolders: [{ uri: rootUri, name: "project" }],
+      },
+    );
+
+    try {
+      client.start();
+      await client.initialize();
+      servers.ruff = client;
+      log("INFO", "Ruff LSP server ready");
+    } catch (err) {
+      log("ERROR", `Failed to start Ruff LSP: ${err.message}`);
+    }
+  } else {
+    log("INFO", "Ruff LSP skipped (ruff not found)");
+  }
+
+  return servers;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+let httpServer;
+let servers = {};
+
+async function cleanup() {
+  log("INFO", "Cleaning up...");
+
+  for (const [name, client] of Object.entries(servers)) {
+    try {
+      await client.shutdown();
+      log("INFO", `[${name}] shut down`);
+    } catch (err) {
+      log("ERROR", `[${name}] shutdown error: ${err.message}`);
+    }
+  }
+
+  try {
+    if (httpServer) httpServer.close();
+  } catch {
+    // ignore
+  }
+
+  // Remove runtime files
+  for (const f of [PID_FILE, SOCKET_FILE, SOCKET_PATH]) {
+    try {
+      if (existsSync(f)) unlinkSync(f);
+    } catch {
+      // ignore
+    }
+  }
+
+  process.exit(0);
+}
+
+async function main() {
+  // Ensure state directory exists
+  if (!existsSync(STATE_DIR)) {
+    mkdirSync(STATE_DIR, { recursive: true });
+  }
+
+  // Clean up stale socket file
+  if (existsSync(SOCKET_PATH)) {
+    try {
+      unlinkSync(SOCKET_PATH);
+    } catch {
+      // ignore
+    }
+  }
+
+  // Truncate old log
+  try {
+    writeFileSync(LOG_FILE, "");
+  } catch {
+    // ignore
+  }
+
+  log("INFO", `LSP Bridge starting (project: ${PROJECT_DIR})`);
+
+  // Start all available LSP servers
+  servers = await createServers();
+
+  const serverNames = Object.keys(servers);
+  if (serverNames.length === 0) {
+    log("ERROR", "No LSP servers could be started. Exiting.");
+    process.exit(1);
+  }
+
+  log("INFO", `Active LSP servers: ${serverNames.join(", ")}`);
+
+  // Start HTTP server on Unix socket
+  httpServer = createApiServer(servers);
+
+  await new Promise((resolve, reject) => {
+    httpServer.on("error", reject);
+    httpServer.listen(SOCKET_PATH, () => {
+      log("INFO", `HTTP API listening on ${SOCKET_PATH}`);
+      resolve();
+    });
+  });
+
+  // Write PID and socket path for hooks to discover
+  writeFileSync(PID_FILE, process.pid.toString());
+  writeFileSync(SOCKET_FILE, SOCKET_PATH);
+
+  log("INFO", `LSP Bridge running (PID ${process.pid}, socket ${SOCKET_PATH})`);
+
+  // Handle signals
+  process.on("SIGTERM", cleanup);
+  process.on("SIGINT", cleanup);
+  process.on("SIGHUP", cleanup);
+}
+
+main().catch((err) => {
+  log("ERROR", `Fatal: ${err.message}`);
+  process.exit(1);
+});

--- a/.claude/hooks/lsp-diagnostics-check.sh
+++ b/.claude/hooks/lsp-diagnostics-check.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# PostToolUse Hook: LSP Diagnostics Check
+#
+# Queries the LSP bridge daemon for TypeScript/Python diagnostics after a
+# file is written or edited. Returns errors/warnings as additionalContext
+# so Claude sees them immediately.
+#
+# Input (stdin): JSON with tool_input.file_path
+# Output (stdout): JSON with hookSpecificOutput.additionalContext (if errors)
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+SOCKET_FILE="$PROJECT_DIR/.claude/hooks/lsp-bridge.socket"
+
+# Read the hook input from stdin
+INPUT=$(cat)
+
+# Extract the file path
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  echo '{}'
+  exit 0
+fi
+
+# Only check supported file types (TypeScript/JavaScript/Python)
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.py|*.pyi) ;;
+  *)
+    echo '{}'
+    exit 0
+    ;;
+esac
+
+# Check if the LSP bridge is running
+if [ ! -f "$SOCKET_FILE" ]; then
+  # Bridge not running — skip silently
+  echo '{}'
+  exit 0
+fi
+
+SOCKET_PATH=$(cat "$SOCKET_FILE")
+
+if [ ! -S "$SOCKET_PATH" ]; then
+  # Socket doesn't exist — bridge probably died
+  echo '{}'
+  exit 0
+fi
+
+# Query the bridge for diagnostics
+RESPONSE=$(curl -s --unix-socket "$SOCKET_PATH" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"file\": \"$FILE_PATH\"}" \
+  "http://localhost/diagnostics" 2>/dev/null) || {
+  # curl failed — bridge may be down
+  echo '{}'
+  exit 0
+}
+
+# Check if we got a valid response with diagnostics
+DIAG_COUNT=$(echo "$RESPONSE" | jq '.diagnostics | length' 2>/dev/null) || {
+  echo '{}'
+  exit 0
+}
+
+if [ "$DIAG_COUNT" -eq 0 ]; then
+  echo '{}'
+  exit 0
+fi
+
+# Format diagnostics into a readable string for Claude
+CONTEXT=$(echo "$RESPONSE" | jq -r '
+  .diagnostics[] |
+  "\(.severity | ascii_upcase): \(.message) (line \(.range.start.line), col \(.range.start.character))" +
+  (if .code then " [\(.source) \(.code | tostring)]" else "" end)
+')
+
+# Build the hook response with additionalContext
+jq -n --arg ctx "LSP Diagnostics for $FILE_PATH:
+$CONTEXT" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $ctx
+  }
+}'

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -52,6 +52,12 @@ if [ -f "package.json" ] && [ ! -d "node_modules" ]; then
   npm install
 fi
 
+# Ensure frontend npm dependencies are installed
+if [ -f "frontend/package.json" ] && [ ! -d "frontend/node_modules" ]; then
+  echo "Installing frontend npm dependencies..."
+  (cd frontend && npm install)
+fi
+
 # Ensure Python dependencies are synced if pyproject.toml exists
 if [ -f "pyproject.toml" ] && command -v uv &> /dev/null; then
   echo "Syncing Python dependencies with uv..."
@@ -78,6 +84,63 @@ if [ -f ".pre-commit-config.yaml" ]; then
       pre-commit install
     fi
   fi
+fi
+
+# Start the LSP bridge daemon for TypeScript and Python diagnostics
+start_lsp_bridge() {
+  local PID_FILE="$CLAUDE_PROJECT_DIR/.claude/hooks/lsp-bridge.pid"
+  local BRIDGE_SCRIPT="$CLAUDE_PROJECT_DIR/.claude/hooks/lsp-bridge.mjs"
+
+  # Check if bridge is already running
+  if [ -f "$PID_FILE" ]; then
+    local OLD_PID
+    OLD_PID=$(cat "$PID_FILE")
+    if kill -0 "$OLD_PID" 2>/dev/null; then
+      echo "LSP bridge already running (PID $OLD_PID)"
+      return 0
+    fi
+    # Stale PID file — clean up
+    rm -f "$PID_FILE"
+  fi
+
+  # Check if at least one LSP server can be started
+  local HAS_TS=false
+  local HAS_RUFF=false
+
+  if [ -f "frontend/node_modules/.bin/typescript-language-server" ]; then
+    HAS_TS=true
+  fi
+
+  if command -v ruff &> /dev/null; then
+    HAS_RUFF=true
+  fi
+
+  if [ "$HAS_TS" = false ] && [ "$HAS_RUFF" = false ]; then
+    echo "No LSP servers available, skipping LSP bridge"
+    return 0
+  fi
+
+  echo "Starting LSP bridge daemon..."
+  nohup node "$BRIDGE_SCRIPT" > /dev/null 2>&1 &
+
+  # Wait briefly for the bridge to initialize
+  sleep 3
+
+  if [ -f "$PID_FILE" ]; then
+    local BRIDGE_PID
+    BRIDGE_PID=$(cat "$PID_FILE")
+    local SERVERS=""
+    [ "$HAS_TS" = true ] && SERVERS="TypeScript"
+    [ "$HAS_RUFF" = true ] && SERVERS="${SERVERS:+$SERVERS + }Ruff (Python)"
+    echo "LSP bridge started (PID $BRIDGE_PID) — $SERVERS diagnostics active"
+  else
+    echo "Warning: LSP bridge may have failed to start. Check .claude/hooks/lsp-bridge.log"
+  fi
+}
+
+# Start bridge if TypeScript or Python sources exist
+if [ -f "frontend/tsconfig.json" ] || [ -f "pyproject.toml" ]; then
+  start_lsp_bridge
 fi
 
 # Provide development context

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -93,6 +93,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-tool-use.py",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lsp-diagnostics-check.sh",
+            "timeout": 20
           }
         ]
       }
@@ -103,7 +108,18 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh",
-            "timeout": 60
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lsp-bridge-stop.sh",
+            "timeout": 10
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@ ehthumbs.db
 .env
 .env.local
 
+# LSP bridge runtime files
+.claude/hooks/lsp-bridge.pid
+.claude/hooks/lsp-bridge.socket
+.claude/hooks/lsp-bridge.log
+
 # Frontend
 frontend/node_modules/
 frontend/dist/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,7 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
+        "typescript-language-server": "^5.1.3",
         "vite": "^7.2.4"
       }
     },
@@ -157,7 +158,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3900,7 +3900,6 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3911,7 +3910,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3922,7 +3920,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3985,7 +3982,6 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -4251,7 +4247,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4397,7 +4392,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4674,7 +4668,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5084,7 +5077,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5379,7 +5371,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7025,7 +7016,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -7662,8 +7652,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -7929,7 +7918,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8045,7 +8033,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8055,7 +8042,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8756,7 +8742,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8789,6 +8774,19 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/typescript-language-server": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-5.1.3.tgz",
+      "integrity": "sha512-r+pAcYtWdN8tKlYZPwiiHNA2QPjXnI02NrW5Sf2cVM3TRtuQ3V9EKKwOxqwaQ0krsaEXk/CbN90I5erBuf84Vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "typescript-language-server": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
@@ -8807,7 +8805,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -9080,7 +9077,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9260,7 +9256,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
+    "typescript-language-server": "^5.1.3",
     "vite": "^7.2.4"
   }
 }


### PR DESCRIPTION
Implements a hook-based LSP integration that gives Claude immediate
feedback on type errors and lint issues after every file edit:

- lsp-bridge.mjs: Node.js daemon that spawns typescript-language-server
  and ruff server, exposes diagnostics via HTTP over a Unix socket
- lsp-diagnostics-check.sh: PostToolUse hook that queries the bridge
  and returns errors as additionalContext for Claude
- lsp-bridge-stop.sh: SessionEnd hook for graceful cleanup
- SessionStart hook updated to launch the bridge on session init
- Supports TS/TSX/JS/JSX (TypeScript LSP) and PY/PYI (Ruff LSP)

https://claude.ai/code/session_01NcJsXD2kDyB6cVoEEZaYRF